### PR TITLE
homomorphic mapped types preserve call and constructor signatures

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13588,14 +13588,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const modifiersType = getApparentType(getModifiersTypeFromMappedType(type)); // The 'T' in 'keyof T'
         const templateModifiers = getMappedTypeModifiers(type);
         const include = keyofStringsOnly ? TypeFlags.StringLiteral : TypeFlags.StringOrNumberLiteralOrUnique;
+        let callSignatures: readonly Signature[] = emptyArray;
+        let constructSignatures: readonly Signature[] = emptyArray;
         if (isMappedTypeWithKeyofConstraintDeclaration(type)) {
             // We have a { [P in keyof T]: X }
             forEachMappedTypePropertyKeyTypeAndIndexSignatureKeyType(modifiersType, include, keyofStringsOnly, addMemberForKeyType);
+            callSignatures = getSignaturesOfType(modifiersType, SignatureKind.Call);
+            constructSignatures = getSignaturesOfType(modifiersType, SignatureKind.Construct);
         }
         else {
             forEachType(getLowerBoundOfKeyType(constraintType), addMemberForKeyType);
         }
-        setStructuredTypeMembers(type, members, emptyArray, emptyArray, indexInfos || emptyArray);
+        setStructuredTypeMembers(type, members, callSignatures, constructSignatures, indexInfos || emptyArray);
 
         function addMemberForKeyType(keyType: Type) {
             const propNameType = nameType ? instantiateType(nameType, appendTypeMapping(type.mapper, typeParameter, keyType)) : keyType;

--- a/tests/baselines/reference/accessorsOverrideProperty9.js
+++ b/tests/baselines/reference/accessorsOverrideProperty9.js
@@ -5,9 +5,9 @@
 
 // Mixin utilities
 export type Constructor<T = {}> = new (...args: any[]) => T;
-export type PropertiesOf<T> = { [K in keyof T]: T[K] };
+export type PropertiesOf<T> = { [K in keyof T & PropertyKey]: T[K] };
 
-interface IApiItemConstructor extends Constructor<ApiItem>, PropertiesOf<typeof ApiItem> {}
+interface IApiItemConstructor extends PropertiesOf<typeof ApiItem>, Constructor<ApiItem> {}
 
 // Base class
 class ApiItem {

--- a/tests/baselines/reference/accessorsOverrideProperty9.symbols
+++ b/tests/baselines/reference/accessorsOverrideProperty9.symbols
@@ -10,19 +10,20 @@ export type Constructor<T = {}> = new (...args: any[]) => T;
 >args : Symbol(args, Decl(accessorsOverrideProperty9.ts, 3, 39))
 >T : Symbol(T, Decl(accessorsOverrideProperty9.ts, 3, 24))
 
-export type PropertiesOf<T> = { [K in keyof T]: T[K] };
+export type PropertiesOf<T> = { [K in keyof T & PropertyKey]: T[K] };
 >PropertiesOf : Symbol(PropertiesOf, Decl(accessorsOverrideProperty9.ts, 3, 60))
 >T : Symbol(T, Decl(accessorsOverrideProperty9.ts, 4, 25))
 >K : Symbol(K, Decl(accessorsOverrideProperty9.ts, 4, 33))
 >T : Symbol(T, Decl(accessorsOverrideProperty9.ts, 4, 25))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.es5.d.ts, --, --))
 >T : Symbol(T, Decl(accessorsOverrideProperty9.ts, 4, 25))
 >K : Symbol(K, Decl(accessorsOverrideProperty9.ts, 4, 33))
 
-interface IApiItemConstructor extends Constructor<ApiItem>, PropertiesOf<typeof ApiItem> {}
->IApiItemConstructor : Symbol(IApiItemConstructor, Decl(accessorsOverrideProperty9.ts, 4, 55))
->Constructor : Symbol(Constructor, Decl(accessorsOverrideProperty9.ts, 0, 0))
->ApiItem : Symbol(ApiItem, Decl(accessorsOverrideProperty9.ts, 6, 91))
+interface IApiItemConstructor extends PropertiesOf<typeof ApiItem>, Constructor<ApiItem> {}
+>IApiItemConstructor : Symbol(IApiItemConstructor, Decl(accessorsOverrideProperty9.ts, 4, 69))
 >PropertiesOf : Symbol(PropertiesOf, Decl(accessorsOverrideProperty9.ts, 3, 60))
+>ApiItem : Symbol(ApiItem, Decl(accessorsOverrideProperty9.ts, 6, 91))
+>Constructor : Symbol(Constructor, Decl(accessorsOverrideProperty9.ts, 0, 0))
 >ApiItem : Symbol(ApiItem, Decl(accessorsOverrideProperty9.ts, 6, 91))
 
 // Base class
@@ -58,7 +59,7 @@ interface ApiItemContainerMixin extends ApiItem {
 function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
 >ApiItemContainerMixin : Symbol(ApiItemContainerMixin, Decl(accessorsOverrideProperty9.ts, 22, 1), Decl(accessorsOverrideProperty9.ts, 17, 1))
 >TBaseClass : Symbol(TBaseClass, Decl(accessorsOverrideProperty9.ts, 24, 31))
->IApiItemConstructor : Symbol(IApiItemConstructor, Decl(accessorsOverrideProperty9.ts, 4, 55))
+>IApiItemConstructor : Symbol(IApiItemConstructor, Decl(accessorsOverrideProperty9.ts, 4, 69))
 
   baseClass: TBaseClass
 >baseClass : Symbol(baseClass, Decl(accessorsOverrideProperty9.ts, 24, 71))

--- a/tests/baselines/reference/accessorsOverrideProperty9.types
+++ b/tests/baselines/reference/accessorsOverrideProperty9.types
@@ -8,10 +8,10 @@ export type Constructor<T = {}> = new (...args: any[]) => T;
 >Constructor : Constructor<T>
 >args : any[]
 
-export type PropertiesOf<T> = { [K in keyof T]: T[K] };
+export type PropertiesOf<T> = { [K in keyof T & PropertyKey]: T[K] };
 >PropertiesOf : PropertiesOf<T>
 
-interface IApiItemConstructor extends Constructor<ApiItem>, PropertiesOf<typeof ApiItem> {}
+interface IApiItemConstructor extends PropertiesOf<typeof ApiItem>, Constructor<ApiItem> {}
 >ApiItem : typeof ApiItem
 
 // Base class

--- a/tests/baselines/reference/homomorphicMappedTypesPreserveCallConstructorSignatures.js
+++ b/tests/baselines/reference/homomorphicMappedTypesPreserveCallConstructorSignatures.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/homomorphicMappedTypesPreserveCallConstructorSignatures.ts] ////
+
+//// [homomorphicMappedTypesPreserveCallConstructorSignatures.ts]
+type YesWithRenaming<T> = { [P in keyof T as `${P & string}bla`]: { value: YesWithRenaming<T[P]> } };
+type YesWithoutRenaming<T> = { [P in keyof T]: { value: YesWithoutRenaming<T[P]> } };
+type NoBecauseNotHomomorphic<T> = { [P in keyof T & PropertyKey]: { value: NoBecauseNotHomomorphic<T[P]> } };
+
+interface Foo {
+  (): string;
+  (x: number): number;
+  prop: string;
+}
+
+interface Test {
+  a: string;
+  b: number;
+  (): boolean;
+  new(arg: unknown): { prop: unknown}
+  readonly nested: {
+    (): string;
+    c?: boolean;
+    new(arg: unknown): { prop: unknown}
+    readonly d: Foo
+  }
+}
+
+type T1 = YesWithRenaming<Test>
+type T2 = YesWithoutRenaming<Test>
+type T3 = NoBecauseNotHomomorphic<Test>
+
+//// [homomorphicMappedTypesPreserveCallConstructorSignatures.js]
+"use strict";

--- a/tests/baselines/reference/homomorphicMappedTypesPreserveCallConstructorSignatures.symbols
+++ b/tests/baselines/reference/homomorphicMappedTypesPreserveCallConstructorSignatures.symbols
@@ -1,0 +1,92 @@
+//// [tests/cases/compiler/homomorphicMappedTypesPreserveCallConstructorSignatures.ts] ////
+
+=== homomorphicMappedTypesPreserveCallConstructorSignatures.ts ===
+type YesWithRenaming<T> = { [P in keyof T as `${P & string}bla`]: { value: YesWithRenaming<T[P]> } };
+>YesWithRenaming : Symbol(YesWithRenaming, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 0))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 21))
+>P : Symbol(P, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 29))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 21))
+>P : Symbol(P, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 29))
+>value : Symbol(value, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 67))
+>YesWithRenaming : Symbol(YesWithRenaming, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 0))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 21))
+>P : Symbol(P, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 29))
+
+type YesWithoutRenaming<T> = { [P in keyof T]: { value: YesWithoutRenaming<T[P]> } };
+>YesWithoutRenaming : Symbol(YesWithoutRenaming, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 101))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 24))
+>P : Symbol(P, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 32))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 24))
+>value : Symbol(value, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 48))
+>YesWithoutRenaming : Symbol(YesWithoutRenaming, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 101))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 24))
+>P : Symbol(P, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 32))
+
+type NoBecauseNotHomomorphic<T> = { [P in keyof T & PropertyKey]: { value: NoBecauseNotHomomorphic<T[P]> } };
+>NoBecauseNotHomomorphic : Symbol(NoBecauseNotHomomorphic, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 85))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 2, 29))
+>P : Symbol(P, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 2, 37))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 2, 29))
+>PropertyKey : Symbol(PropertyKey, Decl(lib.es5.d.ts, --, --))
+>value : Symbol(value, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 2, 67))
+>NoBecauseNotHomomorphic : Symbol(NoBecauseNotHomomorphic, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 85))
+>T : Symbol(T, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 2, 29))
+>P : Symbol(P, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 2, 37))
+
+interface Foo {
+>Foo : Symbol(Foo, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 2, 109))
+
+  (): string;
+  (x: number): number;
+>x : Symbol(x, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 6, 3))
+
+  prop: string;
+>prop : Symbol(Foo.prop, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 6, 22))
+}
+
+interface Test {
+>Test : Symbol(Test, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 8, 1))
+
+  a: string;
+>a : Symbol(Test.a, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 10, 16))
+
+  b: number;
+>b : Symbol(Test.b, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 11, 12))
+
+  (): boolean;
+  new(arg: unknown): { prop: unknown}
+>arg : Symbol(arg, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 14, 6))
+>prop : Symbol(prop, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 14, 22))
+
+  readonly nested: {
+>nested : Symbol(Test.nested, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 14, 37))
+
+    (): string;
+    c?: boolean;
+>c : Symbol(c, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 16, 15))
+
+    new(arg: unknown): { prop: unknown}
+>arg : Symbol(arg, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 18, 8))
+>prop : Symbol(prop, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 18, 24))
+
+    readonly d: Foo
+>d : Symbol(d, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 18, 39))
+>Foo : Symbol(Foo, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 2, 109))
+  }
+}
+
+type T1 = YesWithRenaming<Test>
+>T1 : Symbol(T1, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 21, 1))
+>YesWithRenaming : Symbol(YesWithRenaming, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 0))
+>Test : Symbol(Test, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 8, 1))
+
+type T2 = YesWithoutRenaming<Test>
+>T2 : Symbol(T2, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 23, 31))
+>YesWithoutRenaming : Symbol(YesWithoutRenaming, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 0, 101))
+>Test : Symbol(Test, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 8, 1))
+
+type T3 = NoBecauseNotHomomorphic<Test>
+>T3 : Symbol(T3, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 24, 34))
+>NoBecauseNotHomomorphic : Symbol(NoBecauseNotHomomorphic, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 1, 85))
+>Test : Symbol(Test, Decl(homomorphicMappedTypesPreserveCallConstructorSignatures.ts, 8, 1))
+

--- a/tests/baselines/reference/homomorphicMappedTypesPreserveCallConstructorSignatures.types
+++ b/tests/baselines/reference/homomorphicMappedTypesPreserveCallConstructorSignatures.types
@@ -1,0 +1,61 @@
+//// [tests/cases/compiler/homomorphicMappedTypesPreserveCallConstructorSignatures.ts] ////
+
+=== homomorphicMappedTypesPreserveCallConstructorSignatures.ts ===
+type YesWithRenaming<T> = { [P in keyof T as `${P & string}bla`]: { value: YesWithRenaming<T[P]> } };
+>YesWithRenaming : YesWithRenaming<T>
+>value : YesWithRenaming<T[P]>
+
+type YesWithoutRenaming<T> = { [P in keyof T]: { value: YesWithoutRenaming<T[P]> } };
+>YesWithoutRenaming : YesWithoutRenaming<T>
+>value : YesWithoutRenaming<T[P]>
+
+type NoBecauseNotHomomorphic<T> = { [P in keyof T & PropertyKey]: { value: NoBecauseNotHomomorphic<T[P]> } };
+>NoBecauseNotHomomorphic : NoBecauseNotHomomorphic<T>
+>value : NoBecauseNotHomomorphic<T[P]>
+
+interface Foo {
+  (): string;
+  (x: number): number;
+>x : number
+
+  prop: string;
+>prop : string
+}
+
+interface Test {
+  a: string;
+>a : string
+
+  b: number;
+>b : number
+
+  (): boolean;
+  new(arg: unknown): { prop: unknown}
+>arg : unknown
+>prop : unknown
+
+  readonly nested: {
+>nested : { (): string; new (arg: unknown): {    prop: unknown;}; c?: boolean | undefined; readonly d: Foo; }
+
+    (): string;
+    c?: boolean;
+>c : boolean | undefined
+
+    new(arg: unknown): { prop: unknown}
+>arg : unknown
+>prop : unknown
+
+    readonly d: Foo
+>d : Foo
+  }
+}
+
+type T1 = YesWithRenaming<Test>
+>T1 : YesWithRenaming<Test>
+
+type T2 = YesWithoutRenaming<Test>
+>T2 : YesWithoutRenaming<Test>
+
+type T3 = NoBecauseNotHomomorphic<Test>
+>T3 : { a: { value: NoBecauseNotHomomorphic<string>; }; b: { value: NoBecauseNotHomomorphic<number>; }; nested: { value: NoBecauseNotHomomorphic<{ (): string; new (arg: unknown): { prop: unknown; }; c?: boolean | undefined; readonly d: Foo; }>; }; }
+

--- a/tests/baselines/reference/jsEmitIntersectionProperty.js
+++ b/tests/baselines/reference/jsEmitIntersectionProperty.js
@@ -14,7 +14,7 @@ declare class CoreObject {
   >(
     this: Statics & { new(): Instance },
     arg1: T1
-  ): Readonly<Statics> & { new(): T1 & Instance };
+  ): Readonly<{[K in keyof Statics & PropertyKey]: Statics[K]}> & { new(): T1 & Instance };
 
   toString(): string;
 }

--- a/tests/cases/compiler/homomorphicMappedTypesPreserveCallConstructorSignatures.ts
+++ b/tests/cases/compiler/homomorphicMappedTypesPreserveCallConstructorSignatures.ts
@@ -1,0 +1,28 @@
+// @strict: true
+
+type YesWithRenaming<T> = { [P in keyof T as `${P & string}bla`]: { value: YesWithRenaming<T[P]> } };
+type YesWithoutRenaming<T> = { [P in keyof T]: { value: YesWithoutRenaming<T[P]> } };
+type NoBecauseNotHomomorphic<T> = { [P in keyof T & PropertyKey]: { value: NoBecauseNotHomomorphic<T[P]> } };
+
+interface Foo {
+  (): string;
+  (x: number): number;
+  prop: string;
+}
+
+interface Test {
+  a: string;
+  b: number;
+  (): boolean;
+  new(arg: unknown): { prop: unknown}
+  readonly nested: {
+    (): string;
+    c?: boolean;
+    new(arg: unknown): { prop: unknown}
+    readonly d: Foo
+  }
+}
+
+type T1 = YesWithRenaming<Test>
+type T2 = YesWithoutRenaming<Test>
+type T3 = NoBecauseNotHomomorphic<Test>

--- a/tests/cases/compiler/jsEmitIntersectionProperty.ts
+++ b/tests/cases/compiler/jsEmitIntersectionProperty.ts
@@ -19,7 +19,7 @@ declare class CoreObject {
   >(
     this: Statics & { new(): Instance },
     arg1: T1
-  ): Readonly<Statics> & { new(): T1 & Instance };
+  ): Readonly<{[K in keyof Statics & PropertyKey]: Statics[K]}> & { new(): T1 & Instance };
 
   toString(): string;
 }

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
@@ -4,9 +4,9 @@
 
 // Mixin utilities
 export type Constructor<T = {}> = new (...args: any[]) => T;
-export type PropertiesOf<T> = { [K in keyof T]: T[K] };
+export type PropertiesOf<T> = { [K in keyof T & PropertyKey]: T[K] };
 
-interface IApiItemConstructor extends Constructor<ApiItem>, PropertiesOf<typeof ApiItem> {}
+interface IApiItemConstructor extends PropertiesOf<typeof ApiItem>, Constructor<ApiItem> {}
 
 // Base class
 class ApiItem {


### PR DESCRIPTION
First steps in the compiler